### PR TITLE
Better api feedback for (probably) existing objects

### DIFF
--- a/bytes/api/v2/router.py
+++ b/bytes/api/v2/router.py
@@ -1,16 +1,17 @@
 import logging
-from typing import Dict, Optional, List
+from typing import Optional, List
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Query
 from fastapi.responses import Response
 from pydantic import BaseModel
+from starlette.responses import JSONResponse
 
 from bytes.auth import authenticate_token
 from bytes.events.events import RawFileReceived, NormalizerMetaReceived
 from bytes.events.manager import EventManager
 from bytes.models import BoefjeMeta, MimeType, NormalizerMeta, RawData, RawDataMeta
 from bytes.rabbitmq import create_event_manager
-from bytes.database.sql_meta_repository import create_meta_data_repository, ObjectNotFoundException
+from bytes.database.sql_meta_repository import create_meta_data_repository, ObjectNotFoundException, ObjectAlreadyExists
 from bytes.repositories.meta_repository import MetaDataRepository, BoefjeMetaFilter, RawDataFilter
 
 logger = logging.getLogger(__name__)
@@ -24,11 +25,14 @@ RAW_TAG = "Raw"
 def create_boefje_meta(
     boefje_meta: BoefjeMeta,
     meta_repository: MetaDataRepository = Depends(create_meta_data_repository),
-) -> Dict[str, str]:
-    with meta_repository:
-        meta_repository.save_boefje_meta(boefje_meta)
+) -> JSONResponse:
+    try:
+        with meta_repository:
+            meta_repository.save_boefje_meta(boefje_meta)
+    except ObjectAlreadyExists:
+        return JSONResponse({"status": "failed", "message": "Object already exists"}, status_code=400)
 
-    return {"status": "success"}
+    return JSONResponse({"status": "success"}, status_code=201)
 
 
 @router.get("/boefje_meta/{boefje_meta_id}", response_model=BoefjeMeta, tags=[BOEFJE_META_TAG])
@@ -71,9 +75,12 @@ def create_normalizer_meta(
     normalizer_meta: NormalizerMeta,
     meta_repository: MetaDataRepository = Depends(create_meta_data_repository),
     event_manager: EventManager = Depends(create_event_manager),
-) -> Dict[str, str]:
-    with meta_repository:
-        meta_repository.save_normalizer_meta(normalizer_meta)
+) -> JSONResponse:
+    try:
+        with meta_repository:
+            meta_repository.save_normalizer_meta(normalizer_meta)
+    except ObjectAlreadyExists:
+        return JSONResponse({"status": "failed", "message": "Object already exists"}, status_code=400)
 
     event = NormalizerMetaReceived(
         organization=normalizer_meta.boefje_meta.organization,
@@ -81,7 +88,7 @@ def create_normalizer_meta(
     )
     event_manager.publish(event)
 
-    return {"status": "success"}
+    return JSONResponse({"status": "success"}, status_code=201)
 
 
 @router.get("/normalizer_meta/{normalizer_meta_id}", response_model=NormalizerMeta, tags=[NORMALIZER_META_TAG])

--- a/bytes/database/sql_meta_repository.py
+++ b/bytes/database/sql_meta_repository.py
@@ -45,7 +45,7 @@ class SQLMetaDataRepository(MetaDataRepository):
         try:
             self.session.commit()
         except IntegrityError as e:
-            raise ObjectAlreadyExists(str(e)) from e
+            raise MetaIntegrityError(str(e)) from e
 
     def save_boefje_meta(self, boefje_meta: BoefjeMeta) -> None:
         logger.info("Inserting meta: %s", boefje_meta.json())
@@ -200,7 +200,7 @@ class ObjectNotFoundException(Exception):
         super().__init__(f"The object of type {cls} was not found for query parameters {kwargs}")
 
 
-class ObjectAlreadyExists(Exception):
+class MetaIntegrityError(Exception):
     def __init__(self, message: str):
         super().__init__(message)
 

--- a/bytes/database/sql_meta_repository.py
+++ b/bytes/database/sql_meta_repository.py
@@ -2,6 +2,7 @@ import logging
 import uuid
 from typing import Type, List, Iterator, Optional
 
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import sessionmaker, Session
 
 from bytes.config import Settings, get_settings
@@ -40,7 +41,11 @@ class SQLMetaDataRepository(MetaDataRepository):
 
     def __exit__(self, _exc_type: Type[Exception], _exc_value: str, _exc_traceback: str) -> None:
         logger.info("Committing session")
-        self.session.commit()
+
+        try:
+            self.session.commit()
+        except IntegrityError as e:
+            raise ObjectAlreadyExists(str(e)) from e
 
     def save_boefje_meta(self, boefje_meta: BoefjeMeta) -> None:
         logger.info("Inserting meta: %s", boefje_meta.json())
@@ -193,6 +198,11 @@ def create_meta_data_repository() -> Iterator[MetaDataRepository]:
 class ObjectNotFoundException(Exception):
     def __init__(self, cls: Type[SQL_BASE], **kwargs):  # type: ignore
         super().__init__(f"The object of type {cls} was not found for query parameters {kwargs}")
+
+
+class ObjectAlreadyExists(Exception):
+    def __init__(self, message: str):
+        super().__init__(message)
 
 
 def to_boefje_meta_in_db(boefje_meta: BoefjeMeta) -> BoefjeMetaInDB:

--- a/tests/client.py
+++ b/tests/client.py
@@ -34,7 +34,7 @@ def retry_with_login(function: ClientSessionMethod) -> ClientSessionMethod:
             return function(self, *args, **kwargs)
         except HTTPError as error:
             if error.response.status_code != 401:
-                raise error from HTTPError
+                raise
 
             self.login()
             return function(self, *args, **kwargs)

--- a/tests/integration/test_bytes_api_client.py
+++ b/tests/integration/test_bytes_api_client.py
@@ -24,6 +24,14 @@ def test_boefje_meta(bytes_api_client: BytesAPIClient) -> None:
 
     assert boefje_meta == retrieved_boefje_meta
 
+    with pytest.raises(HTTPError) as ctx:
+        bytes_api_client.save_boefje_meta(boefje_meta)
+
+    assert ctx._excinfo[1].response.json() == {
+        "status": "failed",
+        "message": "Integrity error: object might already exist",
+    }
+
 
 def test_filtered_boefje_meta(bytes_api_client: BytesAPIClient) -> None:
     boefje_meta = get_boefje_meta()


### PR DESCRIPTION
The main feature is handling IntegrityErrors when committing a transaction of BoefjeMeta and NormalizerMeta objects. This gives better feedback in the boefje/normalizer logs as we see duplicate task handling happening.